### PR TITLE
Update delete-canary-deployment.md

### DIFF
--- a/doc_source/delete-canary-deployment.md
+++ b/doc_source/delete-canary-deployment.md
@@ -32,7 +32,7 @@ To use the AWS CLI to disable a canary release deployment, call the `update-stag
 aws apigateway update-stage \
     --rest-api-id 4wk1k4onj3 \
     --stage-name canary \
-    --patch-operations '["op":"remove", "path":"/canarySettings"]'
+    --patch-operations '[{"op":"remove", "path":"/canarySettings"}]'
 ```
 
 A successful response returns a payload similar to the following:


### PR DESCRIPTION
Added missing braces to --patch-operations CLI arguments

*Issue #, if available:*

*Description of changes:*
The CLI argument for the --patch-operation example was missing the JSON {} around the array contents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
